### PR TITLE
Remplace ggpo.lib par ggpo.dll

### DIFF
--- a/ggpo/config.py
+++ b/ggpo/config.py
@@ -5,5 +5,5 @@ def configure(env):
     env.Append(CPPPATH=["#modules/ggpo/libpath"])
 
     if env["platform"] == "windows":
-        env.Append(LINKFLAGS=["ggpo.dll"])
+        env.Append(LINKFLAGS=["ggpo.lib"])
         env.Append(LIBPATH=["#modules/ggpo/libpath"])


### PR DESCRIPTION
Les fichiers lib permettent de faire le link pendant la compilation et les dll sont utilisées au runtime